### PR TITLE
Replace use of ES6 for..of with `punycode.ucs2.decode`

### DIFF
--- a/uts46.js
+++ b/uts46.js
@@ -13,8 +13,10 @@
 
 function mapLabel(label, useStd3ASCII, transitional) {
   var mapped = [];
-  for (var ch of label) {
-    var cp = ch.codePointAt(0);
+  var chars = punycode.ucs2.decode(label);
+  for (var i = 0; i < chars.length; i++) {
+    var cp = chars[i];
+    var ch = punycode.ucs2.encode([chars[i]]);
     var composite = idna_map.mapChar(cp);
     var flags = (composite >> 23);
     var kind = (composite >> 21) & 3;


### PR DESCRIPTION
(Now confirmed to pass all unit tests!)

This PR replaces the use of `for..of` with `punycode.ucs2.decode` an `punycode.ucs2.encode`, removing the dependency on ES6, and therefore making it more browser-friendly.